### PR TITLE
Apply definition span setting to pgfkeyslibrary env

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-macros.tex
+++ b/doc/generic/pgf/pgfmanual-en-macros.tex
@@ -1129,7 +1129,7 @@
 	\begin{pgfmanualentry}%
 		\pgfmanualentryheadline{%
 			\pgfmanualpdflabel{#1}{}%
-			\textbf{pgfkeys Library} \texttt{\declare{#1}}}%
+			\definitionspan{\textbf{pgfkeys Library} \texttt{\declare{#1}}}}%
 		\index{#1@\protect\texttt{#1} pgfkeys library}%
 		\index{pgfkeys Libraries!#1@\protect\texttt{#1}}%
 		\vskip.25em


### PR DESCRIPTION
**Motivation for this change**

Fix alignment of `pgfkeys` library name in HTML.

Current, library name `filtered` is centered
https://tikz.dev/pgfkeys#pgf.filtered
<img width="730" alt="image" src="https://github.com/user-attachments/assets/470ea1f3-d491-43d3-bab9-813939322341">

Expected, library name `filtered` is left-aligned
<img width="724" alt="image" src="https://github.com/user-attachments/assets/d66d06e1-b96f-4295-a8fc-fce13f5b4866">

The `pgfkeyslibrary` LaTeX environment was added recently in `pgf`, so maybe missing from patching.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
