### PR TITLE
Add link to pdf version of pgf manual

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-library-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shapes.tex
@@ -1839,7 +1839,7 @@ center of the appropriate side.
 \end{pgflibrary}
 
 \BlockClassSingle{warning-see-pdf}{
-For the intended rendering of the following examples, please see the \href{https://pgf-tikz.github.io/pgf/pgfmanual.pdf}{|PDF version|} of the manual.
+For the intended rendering of the following examples, please see the \href{https://pgf-tikz.github.io/pgf/pgfmanual.pdf\#nameddest=subsection.71.7}{PDF version} of the manual.
 
 \includegraphics{standalone/pgfmanual-sec-71-7}
 }

--- a/doc/generic/pgf/pgfmanual-en-library-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shapes.tex
@@ -1839,7 +1839,7 @@ center of the appropriate side.
 \end{pgflibrary}
 
 \BlockClassSingle{warning-see-pdf}{
-For the intended rendering of the following examples, please see the PDF version of the manual.
+For the intended rendering of the following examples, please see the \href{https://pgf-tikz.github.io/pgf/pgfmanual.pdf}{|PDF version|} of the manual.
 
 \includegraphics{standalone/pgfmanual-sec-71-7}
 }

--- a/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
@@ -2907,7 +2907,7 @@ Let us now have a look at a few examples. These examples work only if this
 document is processed with a driver that supports picture remembering.
 
 \BlockClassSingle{warning-see-pdf}{
-For the intended rendering of the following examples, please see the PDF version of the manual.
+For the intended rendering of the following examples, please see the \href{https://pgf-tikz.github.io/pgf/pgfmanual.pdf\#nameddest=subsubsection.17.13.1}{PDF version} of the manual.
 
 \includegraphics{standalone/pgfmanual-sec-17-13-1}
 }


### PR DESCRIPTION
This PR adds a link to the pdf version of the pgf manual.