### PR TITLE
Add links to pdf spec for blend modes

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -222,7 +222,7 @@ renderers, let alone printers, will have trouble rendering blending correctly.
 \begin{key}{/tikz/blend mode=\meta{mode}}
     Sets the current blend mode to \meta{mode}. Here \meta{mode} must be one of
     the modes listed below. More details on these modes can also be found in
-    Section~7.2.4 of the \textsc{pdf} Specification, version~1.7.
+    \href{https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf#G12.12449365}{Section~7.2.4} of the \textsc{pdf} Specification, version~1.7.
 
     In the following example, the blend mode is only used and set inside a
     transparency group (see also Section~\ref{section-transparency-groups}).
@@ -317,7 +317,7 @@ renderers, let alone printers, will have trouble rendering blending correctly.
     \medskip
     \begin{tabular}{lll}
     {\emph{Example}} & {\emph{Mode}} & {\emph{Explanations quoted from
-        Table~7.2 of the \textsc{pdf} Specification, Version~1.7}} \\
+        \href{https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf#G12.12449569}{Table~7.2} of the \textsc{pdf} Specification, Version~1.7}} \\
     \showmode{normal} & \verb|normal| & \showmodeR{When painting a pixel with a some color (called the
         ``source color''), the background color (called the ``backdrop'') is
         completely ignored.}


### PR DESCRIPTION
This PR adds links to the pdf spec, more specifically to the chapter and a table describing blend modes.

- [x] Documentation changes are licensed under [FDLv1.2][FDL]
